### PR TITLE
Validate deserialization context depth

### DIFF
--- a/src/RequestDataInjector.php
+++ b/src/RequestDataInjector.php
@@ -12,6 +12,10 @@ final class RequestDataInjector
     {
         $context = $event->getContext();
 
+        if ($context->getDepth() !== 1) {
+            return;
+        }
+
         $event->setData($this->mergeData($event->getData(), $context));
     }
 

--- a/tests/Unit/RequestDataInjectorTest.php
+++ b/tests/Unit/RequestDataInjectorTest.php
@@ -15,6 +15,24 @@ final class RequestDataInjectorTest extends \PHPUnit\Framework\TestCase
      *
      * @covers \Lcobucci\Chimera\Serialization\Jms\RequestDataInjector
      */
+    public function injectDataShouldBeSkippedWhenContextDepthIsNotOne(): void
+    {
+        $event = $this->createEvent(['foo' => 'bar'], ['bar' => 'baz']);
+
+        /** @var DeserializationContext $context */
+        $context = $event->getContext();
+        $context->increaseDepth();
+
+        $this->processListener($event);
+
+        self::assertSame(['foo' => 'bar'], $event->getData());
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\Chimera\Serialization\Jms\RequestDataInjector
+     */
     public function injectDataShouldAddRouteParamsToData(): void
     {
         $event = $this->createEvent(['foo' => 'bar'], ['bar' => 'baz']);
@@ -78,6 +96,7 @@ final class RequestDataInjectorTest extends \PHPUnit\Framework\TestCase
         ?string $generatedId = null
     ): PreDeserializeEvent {
         $context = DeserializationContext::create();
+        $context->increaseDepth();
 
         if ($routeParams) {
             $context->setAttribute('chimera.route_params', $routeParams);


### PR DESCRIPTION
We should only inject request on the first level, to avoid adding
unnecessary information to the context.